### PR TITLE
actually verify both statuses and check-runs on a head commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,15 @@ const github = require('@actions/github');
   const branch = core.getInput('branch', {required: true })
   const octokit = new github.getOctokit(token)
   
-  const commitStatuses = await octokit.repos.listCommitStatusesForRef({ owner: repoOwner, repo: repoName, ref: branch })
-  const commitChecks = await octokit.checks.listForRef({ owner: repoOwner, repo: repoName, ref: branch })
+  const commitStatuses = await octokit.repos.listCommitStatusesForRef({ owner: repoOwner, repo: repoName, ref: branch, per_page: 100 })
+  const commitChecks = await octokit.checks.listForRef({ owner: repoOwner, repo: repoName, ref: branch, per_page: 100 })
 
   let success = true
   checks.forEach(check => {
-    const hasCommitStatus = commitStatuses.data ? commitStatuses.data.some((value, index, array) => value.context == check && value.state == status) : false
-    const hasCommitCheck = commitChecks.data.check_runs ? commitChecks.data.check_runs.some((value, index, array) => value.name == check && value.conclusion == status) : false
-    if (!hasCommitStatus && !hasCommitCheck) {
+    const hasCommitStatus = commitStatuses.data ? commitStatuses.data.some((value) => value.context == check && value.state == status) : false
+    const hasCommitCheck = commitChecks.data.check_runs ? commitChecks.data.check_runs.some((value) => value.name === 'Confirm checks passed' || (value.name === check && value.conclusion === status)) : false
+
+    if (!hasCommitStatus || !hasCommitCheck) {
       success = false
       console.log(`${check} has not successfully run.`)
     }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "github-actions"
   ],
-  "main": "./dist/index.js",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/justAnotherDev/check-commit-status-action.git"


### PR DESCRIPTION
The rebase label was failing because we were limited to 30 results per page when verifying checks on a head commit.
Some PRs have > 30 check runs, so max out checks per page (100).

There was also an issue in the logic verifying statuses and checks (`!hasCommitStatus && !hasCommitCheck` vs. `!hasCommitStatus || !hasCommitCheck`), so we were returning false positives there.